### PR TITLE
Fixed env variables terraform passes pipelines

### DIFF
--- a/setup/main.tf
+++ b/setup/main.tf
@@ -239,7 +239,7 @@ resource "aws_ecs_task_definition" "steampulse_review_pipeline_task_definition" 
           "value" : var.DATABASE_PASSWORD
         },
         {
-          "name" : "DATABASE_IP",
+          "name" : "DATABASE_ENDPOINT",
           "value" : "${aws_db_instance.steampulse_database.address}"
         },
         {


### PR DESCRIPTION
One of our pipelines looks for DATABASE_ENDPOINT, one of the looks for DATABASE_IP. 

I don't mind which we go with in the end, but we should pick one and stick to that