### PR TITLE
Adding tests for the whole review pipeline

### DIFF
--- a/pipeline_reviews/conftest.py
+++ b/pipeline_reviews/conftest.py
@@ -3,8 +3,21 @@
 from pytest import fixture
 from pandas import DataFrame
 
+
 @fixture
-def fake_df():
+def fake_df_load():
     """Fake data-frame used for testing"""
     return DataFrame([{"game_id": 2, "test": 9},
         {"game_id": 3, "test": 5}, {"game_id": 8, "test": None}], index=[1,2,3])
+
+
+@fixture
+def fake_review() -> str:
+    """Returns a fake review for testing"""
+    return "Test\n,;review fail"
+
+
+@fixture
+def fake_df_sentiment(fake_review) -> DataFrame:
+    """Returns data-frame used for testing"""
+    return DataFrame([{"review": fake_review}], index=[1])

--- a/pipeline_reviews/conftest.py
+++ b/pipeline_reviews/conftest.py
@@ -6,7 +6,7 @@ from pandas import DataFrame
 
 @fixture
 def fake_df_load():
-    """Fake data-frame used for testing"""
+    """Returns data-frame used for testing"""
     return DataFrame([{"game_id": 2, "test": 9},
         {"game_id": 3, "test": 5}, {"game_id": 8, "test": None}], index=[1,2,3])
 
@@ -18,6 +18,20 @@ def fake_review() -> str:
 
 
 @fixture
-def fake_df_sentiment(fake_review) -> DataFrame:
+def fake_df_sentiment(fake_review: str) -> DataFrame:
     """Returns data-frame used for testing"""
     return DataFrame([{"review": fake_review}], index=[1])
+
+
+@fixture
+def time_string() -> str:
+    """Returns a timestamp string for testing"""
+    return "2019-02-23 12:13:10"
+
+
+@fixture
+def fake_df_transform(time_string: str) -> DataFrame:
+    """Returns data-frame used for testing"""
+    return DataFrame([{"playtime_last_2_weeks": 0, "review_score": 1,
+                    "last_timestamp": time_string, "game_id": 1}, {"playtime_last_2_weeks": 2,
+                    "review_score": 1, "last_timestamp": time_string, "game_id": 2}])

--- a/pipeline_reviews/extract.py
+++ b/pipeline_reviews/extract.py
@@ -19,9 +19,12 @@ class GamesNotFound(Exception):
 
 def get_number_of_reviews(game_id: int) -> dict:
     """Retrieves information about all reviews from a given game ID"""
-    request = requests.get(f"https://store.steampowered.com/appreviews/{game_id}?json=1")
-    reviews_info = request.json()
-    return reviews_info["query_summary"]["total_reviews"]
+    try:
+        request = requests.get(f"https://store.steampowered.com/appreviews/{game_id}?json=1", timeout=10)
+        reviews_info = request.json()
+        return reviews_info["query_summary"]["total_reviews"]
+    except requests.exceptions.Timeout:
+        return 0
 
 
 def get_reviews_for_game(game_id: int, cursor: str) -> dict:
@@ -73,6 +76,7 @@ def get_all_reviews(game_ids: list[int]) -> DataFrame:
                     if not cursor in cursor_list:
                         cursor_list.append(cursor)
                     all_reviews.extend(page_reviews)
+    print(DataFrame(all_reviews))
     return DataFrame(all_reviews)
 
 

--- a/pipeline_reviews/extract.py
+++ b/pipeline_reviews/extract.py
@@ -17,8 +17,8 @@ class GamesNotFound(Exception):
         super().__init__(message)
 
 
-def get_number_of_reviews(game_id: int) -> dict:
-    """Retrieves information about all reviews from a given game ID"""
+def get_number_of_reviews(game_id: int) -> int:
+    """Retrieves total number of all reviews from a given game ID"""
     try:
         request = requests.get(f"https://store.steampowered.com/appreviews/{game_id}?json=1", timeout=10)
         reviews_info = request.json()

--- a/pipeline_reviews/extract.py
+++ b/pipeline_reviews/extract.py
@@ -76,7 +76,6 @@ def get_all_reviews(game_ids: list[int]) -> DataFrame:
                     if not cursor in cursor_list:
                         cursor_list.append(cursor)
                     all_reviews.extend(page_reviews)
-    print(DataFrame(all_reviews))
     return DataFrame(all_reviews)
 
 

--- a/pipeline_reviews/pipeline.py
+++ b/pipeline_reviews/pipeline.py
@@ -6,7 +6,7 @@ from psycopg2 import Error
 
 from extract import get_db_connection, get_game_ids, get_all_reviews, GamesNotFound
 from transform import transform_reviews, remove_unnamed
-from sentiment import isolate_non_stop_words, get_sentiment_per_game, get_sentiment_values
+from sentiment import isolate_non_stop_words, get_sentiment_values
 from load import get_game_ids_foreign_key_values, move_reviews_to_db
 
 if __name__ == "__main__":
@@ -30,7 +30,6 @@ if __name__ == "__main__":
         print("Getting sentiment values...")
         reviews = isolate_non_stop_words(reviews)
         reviews = get_sentiment_values(reviews)
-        each_game_sentiment = get_sentiment_per_game(reviews)
         reviews = remove_unnamed(reviews)
         time_finished_sent = datetime.now()
         time_taken = time_finished_sent - time_finished_transform

--- a/pipeline_reviews/sentiment.py
+++ b/pipeline_reviews/sentiment.py
@@ -2,7 +2,6 @@
 
 from pandas import DataFrame
 from pandas.core.series import Series
-import nltk
 from nltk.corpus import stopwords
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 

--- a/pipeline_reviews/sentiment.py
+++ b/pipeline_reviews/sentiment.py
@@ -1,7 +1,6 @@
 """Sentiment analysis on extracted reviews"""
 
 from pandas import DataFrame
-from pandas.core.series import Series
 from nltk.corpus import stopwords
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 

--- a/pipeline_reviews/sentiment.py
+++ b/pipeline_reviews/sentiment.py
@@ -16,7 +16,7 @@ def remove_stopwords(review: str, stop_words: list[str], punctuation: list[str])
 def isolate_non_stop_words(reviews_df: DataFrame) -> DataFrame:
     """Returns a data-frame ready to process for sentiment scores
     with cleaned text in reviews section"""
-    stop_words = stopwords.words('english')
+    stop_words = stopwords.words("english")
     punctuation_and_more = ["/",".",",","@","£","#","+","=","_",
             "-",")","(","*","^","%","$","~","`","'",'"',"<",">","1",
             "0","2","3","4","5","6","7","8","9",";",":","|","{","}","[","]"]
@@ -35,13 +35,3 @@ def get_sentiment_values(reviews_df: DataFrame) -> DataFrame:
             lambda score: round((score + 1)/2 * 5, 1))
     reviews_df_copy.drop(columns=["clean_review"], inplace=True)
     return reviews_df_copy
-
-
-def get_sentiment_per_game(reviews_df: DataFrame) -> Series:
-    """Returns pandas series object with sentiment scores overall
-    for each game ID"""
-    each_game_sentiment_overall = reviews_df.groupby("game_id").sum("sentiment")["sentiment"]
-    n_cols = reviews_df.groupby("game_id").count()["sentiment"]
-    each_game_sentiment_overall = each_game_sentiment_overall.transform(
-        lambda score: score/n_cols[score.index])
-    return each_game_sentiment_overall

--- a/pipeline_reviews/test_extract.py
+++ b/pipeline_reviews/test_extract.py
@@ -19,7 +19,6 @@ def test_get_game_ids_passes():
     assert get_game_ids(fake_connection) == [1, 2]
 
 
-
 def test_get_game_ids_fails():
     """Verifies that extract script raises GamesNotFound
     error if no games were returned"""

--- a/pipeline_reviews/test_extract.py
+++ b/pipeline_reviews/test_extract.py
@@ -1,0 +1,41 @@
+"""File with unit tests for extract.py"""
+
+from unittest.mock import MagicMock
+from pytest import raises
+
+from extract import get_game_ids, GamesNotFound, get_db_connection
+from extract import get_number_of_reviews
+
+
+def test_get_game_ids_passes():
+    """"""
+    fake_connection = MagicMock()
+    fake_cursor = fake_connection.cursor().__enter__()
+    fake_fetch = fake_cursor.fetchall
+    fake_fetch.return_value = [{"app_id": 1},{"app_id": 2}]
+    assert get_game_ids(fake_connection) == [1, 2]
+
+
+
+def test_get_game_ids_fails():
+    """"""
+    fake_connection = MagicMock()
+    fake_cursor = fake_connection.cursor().__enter__()
+    fake_fetch = fake_cursor.fetchall
+    fake_fetch.return_value = []
+    with raises(GamesNotFound):
+        get_game_ids(fake_connection)
+
+
+def test_get_db_connection(monkeypatch):
+    """"""
+    monkeypatch.setattr("extract.connect", lambda **kwargs: None)
+    assert get_db_connection() == None
+
+
+def test_get_number_of_reviews(monkeypatch):
+    """"""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"query_summary": {"total_reviews": "test"}}
+    monkeypatch.setattr("requests.get", lambda *args: fake_response)
+    assert get_number_of_reviews(0) == "test"

--- a/pipeline_reviews/test_extract.py
+++ b/pipeline_reviews/test_extract.py
@@ -1,24 +1,28 @@
 """File with unit tests for extract.py"""
 
-from unittest.mock import MagicMock
+from pandas import DataFrame
 from pytest import raises
+from requests.exceptions import Timeout
+from unittest.mock import MagicMock
 
 from extract import get_game_ids, GamesNotFound, get_db_connection
-from extract import get_number_of_reviews
+from extract import get_number_of_reviews, get_all_reviews, get_reviews_for_game
 
 
 def test_get_game_ids_passes():
-    """"""
+    """Verifies that app_ids were correctly formatted from
+    mocked psql query response"""
     fake_connection = MagicMock()
     fake_cursor = fake_connection.cursor().__enter__()
     fake_fetch = fake_cursor.fetchall
-    fake_fetch.return_value = [{"app_id": 1},{"app_id": 2}]
+    fake_fetch.return_value = [{"app_id": 1}, {"app_id": 2}]
     assert get_game_ids(fake_connection) == [1, 2]
 
 
 
 def test_get_game_ids_fails():
-    """"""
+    """Verifies that extract script raises GamesNotFound
+    error if no games were returned"""
     fake_connection = MagicMock()
     fake_cursor = fake_connection.cursor().__enter__()
     fake_fetch = fake_cursor.fetchall
@@ -28,14 +32,58 @@ def test_get_game_ids_fails():
 
 
 def test_get_db_connection(monkeypatch):
-    """"""
+    """Mocks PSQL connection and checks that it was returned"""
     monkeypatch.setattr("extract.connect", lambda **kwargs: None)
     assert get_db_connection() == None
 
 
 def test_get_number_of_reviews(monkeypatch):
-    """"""
+    """Verifies that get request is correctly finding the number of reviews"""
     fake_response = MagicMock()
     fake_response.json.return_value = {"query_summary": {"total_reviews": "test"}}
-    monkeypatch.setattr("requests.get", lambda *args: fake_response)
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: fake_response)
     assert get_number_of_reviews(0) == "test"
+
+
+def test_get_all_reviews_errors(monkeypatch):
+    """Verifies that if error is found, an empty data-frame is returned"""
+    monkeypatch.setattr("extract.get_number_of_reviews", lambda *args: 0)
+    monkeypatch.setattr("extract.get_reviews_for_game", lambda *args: {"error": "test"})
+    assert get_all_reviews([0]).empty
+
+
+def test_get_all_reviews_no_reviews(monkeypatch):
+    """Verifies that an empty data-frame is created from no reviews"""
+    monkeypatch.setattr("extract.get_number_of_reviews", lambda *args: 1)
+    monkeypatch.setattr("extract.get_reviews_for_game", lambda *args: {
+        "next_cursor": "test", "reviews": []})
+    assert get_all_reviews([0]).empty
+
+
+def test_get_all_reviews_one_review(monkeypatch):
+    """Verifies that data-frame is correctly formed from the data"""
+    monkeypatch.setattr("extract.get_number_of_reviews", lambda *args: 1)
+    fake_reviews = {"next_cursor": "test","reviews": [
+        {"test": "0", "text": "fake review"}]}
+    monkeypatch.setattr("extract.get_reviews_for_game", lambda *args: fake_reviews)
+    expected_result = DataFrame(fake_reviews["reviews"])
+    assert get_all_reviews([0]).equals(expected_result)
+
+
+def test_get_reviews_for_game_raises_error(monkeypatch):
+    """Verifies that the test correctly identifies timeout error"""
+    fake_response = MagicMock()
+    fake_response.json.side_effect = Timeout()
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: fake_response)
+    assert "error" in get_reviews_for_game(10, "").keys()
+
+
+def test_get_reviews_for_game_basic(monkeypatch):
+    """Verifies that reviews from mocked API request are collected correctly"""
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"cursor" : "" ,"reviews": [{"review": 1, "votes_up": 1,
+        "timestamp_created": 1672531200, "author": {"playtime_forever": 10}}]}
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: fake_response)
+    assert get_reviews_for_game(10, "") == {"next_cursor": "", "reviews": [
+        {"game_id": 10, "last_timestamp": "2023-01-01 00:00:00",
+         "playtime_last_2_weeks": 10, "review": 1, "review_score": 1}]}

--- a/pipeline_reviews/test_load.py
+++ b/pipeline_reviews/test_load.py
@@ -5,14 +5,14 @@ from unittest.mock import MagicMock
 from load import get_game_ids_foreign_key_values, get_game_ids, move_reviews_to_db
 
 
-def test_get_game_ids_foreign_key_values(monkeypatch, fake_df):
+def test_get_game_ids_foreign_key_values(monkeypatch, fake_df_load):
     """Verifies that data-frame gets correctly modified with nan
     cell values taken out for the full row and correct game_ids replaced"""
     monkeypatch.setattr("extract.get_db_connection", lambda x: None)
     monkeypatch.setattr("load.get_game_ids", lambda *args: 1)
-    assumed_result_df = fake_df.assign(game_id=1)
+    assumed_result_df = fake_df_load.assign(game_id=1)
     assumed_result_df = assumed_result_df[assumed_result_df["test"].notna()]
-    returned_df = get_game_ids_foreign_key_values(fake_df)
+    returned_df = get_game_ids_foreign_key_values(fake_df_load)
     assert returned_df.equals(assumed_result_df)
 
 
@@ -27,10 +27,10 @@ def test_get_game_ids():
     assert returned_val == 1
 
 
-def test_move_reviews_to_db(monkeypatch, fake_df, capfd):
+def test_move_reviews_to_db(monkeypatch, fake_df_load, capfd):
     """Verifies that execute_batch was called"""
     fake_connection = MagicMock()
     monkeypatch.setattr("load.execute_batch", lambda *args: print("Data committed!"))
-    move_reviews_to_db(fake_connection, fake_df)
+    move_reviews_to_db(fake_connection, fake_df_load)
     captured = capfd.readouterr()
     assert "Data committed!" in captured.out

--- a/pipeline_reviews/test_sentiment.py
+++ b/pipeline_reviews/test_sentiment.py
@@ -1,0 +1,31 @@
+"""File with unit tests for sentiment.py"""
+
+from unittest.mock import MagicMock
+
+from sentiment import remove_stopwords, isolate_non_stop_words, get_sentiment_values
+
+
+def test_remove_stopwords(fake_review):
+    """Verifies that the function correctly removes punctuation
+    and stop words provided"""
+    assert remove_stopwords(fake_review, ["fail"], [";", ","]) == "Test review"
+
+
+def test_isolate_non_stop_words(monkeypatch, fake_df_sentiment):
+    """Verifies that a data-frame column review is correctly modified
+    to not include punctuation and stop words"""
+    monkeypatch.setattr("sentiment.stopwords.words", lambda *args: ["fail"])
+    returned_df = isolate_non_stop_words(fake_df_sentiment)
+    assert "clean_review" in returned_df.columns
+    assert "Test review" in returned_df["clean_review"].values
+
+
+def test_get_sentiment_values(fake_df_sentiment, monkeypatch):
+    """Verifies that sentiment values are correctly returned and formatted"""
+    fake_df_sentiment.rename(columns={"review": "clean_review"}, inplace=True)
+    fake_sentiment_analyser = MagicMock()
+    fake_sentiment_analyser.polarity_scores.return_value = {"compound": 0}
+    monkeypatch.setattr("sentiment.SentimentIntensityAnalyzer",
+                lambda *args: fake_sentiment_analyser)
+    returned_df = get_sentiment_values(fake_df_sentiment)
+    assert returned_df["sentiment"].values[0] == 2.5

--- a/pipeline_reviews/test_transform.py
+++ b/pipeline_reviews/test_transform.py
@@ -1,0 +1,48 @@
+"""File with unit tests for transform.py"""
+
+from datetime import date
+
+from pandas import DataFrame
+from unittest.mock import MagicMock
+
+from transform import get_release_date, remove_empty_rows, validate_time_string
+from transform import remove_duplicate_reviews, remove_unnamed
+
+
+def test_get_release_date():
+    """Verifies that release date returnes correct value"""
+    fake_connection = MagicMock()
+    fake_cursor = fake_connection.cursor().__enter__()
+    fake_fetch = fake_cursor.fetchone.return_value = {"release_date": 1}
+    assert get_release_date(0, fake_connection, {}) == 1
+
+
+def test_remove_empty_rows():
+    """Verifies that empty rows are removed"""
+    fake_df = DataFrame({"test": None}, index=[1])
+    assert remove_empty_rows(fake_df).empty
+
+
+def test_validate_time_string_basic():
+    """Verifies that correct object type
+    is returned (date) from a timestamp string"""
+    timestamp_string = "2019-02-23 12:13:10"
+    assert isinstance(validate_time_string(timestamp_string), date)
+
+
+def test_validate_time_string_error():
+    """Verifies that when error occurs, None is returned"""
+    assert validate_time_string(None) is None
+
+
+def test_remove_duplicate_reviews():
+    """Verifies that duplicate rows are removed"""
+    fake_review = {"review": "test","game_id": 1,"playtime_last_2_weeks": 55}
+    fake_df = DataFrame([fake_review, fake_review])
+    assert remove_duplicate_reviews(fake_df).shape == (1,3)
+
+
+def test_remove_unnamed():
+    """Verifies that unnamed column is removed if exists"""
+    fake_df = DataFrame([{"Unnamed: 0": 1, "test": "test2"}])
+    assert remove_unnamed(fake_df).shape == (1,1)

--- a/pipeline_reviews/test_transform.py
+++ b/pipeline_reviews/test_transform.py
@@ -3,10 +3,12 @@
 from datetime import date
 
 from pandas import DataFrame
+from numpy import int64
 from unittest.mock import MagicMock
 
 from transform import get_release_date, remove_empty_rows, validate_time_string
-from transform import remove_duplicate_reviews, remove_unnamed
+from transform import remove_duplicate_reviews, remove_unnamed, correct_cell_values
+from transform import change_column_types, correct_playtime
 
 
 def test_get_release_date():
@@ -23,11 +25,10 @@ def test_remove_empty_rows():
     assert remove_empty_rows(fake_df).empty
 
 
-def test_validate_time_string_basic():
+def test_validate_time_string_basic(time_string):
     """Verifies that correct object type
     is returned (date) from a timestamp string"""
-    timestamp_string = "2019-02-23 12:13:10"
-    assert isinstance(validate_time_string(timestamp_string), date)
+    assert isinstance(validate_time_string(time_string), date)
 
 
 def test_validate_time_string_error():
@@ -46,3 +47,25 @@ def test_remove_unnamed():
     """Verifies that unnamed column is removed if exists"""
     fake_df = DataFrame([{"Unnamed: 0": 1, "test": "test2"}])
     assert remove_unnamed(fake_df).shape == (1,1)
+
+
+def test_correct_cell_values(fake_df_transform):
+    """Verifies that rows are removed with incorrect cell values"""
+    assert correct_cell_values(fake_df_transform).shape == (1,4)
+
+
+def test_change_column_types(fake_df_transform):
+    """Verifies that column types are correctly changed"""
+    returned_df = change_column_types(fake_df_transform)
+    assert all(isinstance(val, date) for val in returned_df["last_timestamp"].values)
+    assert all(isinstance(val, int64) for val in returned_df["review_score"].values)
+    assert all(isinstance(val, int64) for val in 
+               returned_df["playtime_last_2_weeks"].values)
+
+
+def test_correct_playtime(monkeypatch, time_string, fake_df_transform):
+    """Verifies that function correctly identifies that playtime is valid"""
+    monkeypatch.setattr("transform.get_db_connection", lambda *args: None)
+    monkeypatch.setattr("transform.get_release_date", 
+                    lambda *args: validate_time_string(time_string))
+    assert correct_playtime(fake_df_transform).equals(fake_df_transform)


### PR DESCRIPTION
Finished all tests for the whole pipeline reviews

- fixed some issues with extract.py with added timeout response
- removed unused function in sentiment.py and same from pipeline.py
- corrected typehint and docstring of a get_number_of_reviews function in extract.py